### PR TITLE
Big refactor of machine.rs

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -247,6 +247,82 @@ dependencies = [
 ]
 
 [[package]]
+name = "num"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "43db66d1170d347f9a065114077f7dccb00c1b9478c89384490a3425279a4606"
+dependencies = [
+ "num-bigint",
+ "num-complex",
+ "num-integer",
+ "num-iter",
+ "num-rational",
+ "num-traits",
+]
+
+[[package]]
+name = "num-bigint"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f93ab6289c7b344a8a9f60f88d80aa20032336fe78da341afc91c8a2341fc75f"
+dependencies = [
+ "autocfg",
+ "num-integer",
+ "num-traits",
+]
+
+[[package]]
+name = "num-complex"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "26873667bbbb7c5182d4a37c1add32cdf09f841af72da53318fdb81543c15085"
+dependencies = [
+ "num-traits",
+]
+
+[[package]]
+name = "num-integer"
+version = "0.1.44"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d2cc698a63b549a70bc047073d2949cce27cd1c7b0a4a862d08a8031bc2801db"
+dependencies = [
+ "autocfg",
+ "num-traits",
+]
+
+[[package]]
+name = "num-iter"
+version = "0.1.43"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7d03e6c028c5dc5cac6e2dec0efda81fc887605bb3d884578bb6d6bf7514e252"
+dependencies = [
+ "autocfg",
+ "num-integer",
+ "num-traits",
+]
+
+[[package]]
+name = "num-rational"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d41702bd167c2df5520b384281bc111a4b5efcf7fbc4c9c222c815b07e0a6a6a"
+dependencies = [
+ "autocfg",
+ "num-bigint",
+ "num-integer",
+ "num-traits",
+]
+
+[[package]]
+name = "num-traits"
+version = "0.2.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9a64b1ec5cda2586e284722486d802acf1f7dbdc623e2bfc57e65ca1cd099290"
+dependencies = [
+ "autocfg",
+]
+
+[[package]]
 name = "num_cpus"
 version = "1.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -409,6 +485,7 @@ version = "0.1.0"
 dependencies = [
  "argh",
  "enum-utils",
+ "num",
  "rand",
  "rayon",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,6 +9,7 @@ license = "GPL-2.0"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
+num = "0.4.0"
 argh = "0.1.7"
 rand = "0.8.5"
 enum-utils = "0.1.2"

--- a/src/machine.rs
+++ b/src/machine.rs
@@ -465,7 +465,10 @@ pub enum Test {
 
 #[derive(Copy, Debug, Clone, PartialEq)]
 pub enum MonadicOperation {
-    Complement, Decrement, Increment, Negate, 
+    Complement,
+    Decrement,
+    Increment,
+    Negate,
     // TODO: Move the shifts here.
 }
 

--- a/src/machine.rs
+++ b/src/machine.rs
@@ -424,6 +424,9 @@ impl Instruction {
 
     pub fn randomize(&mut self) {
         self.operation = (self.randomizer)(self.machine);
+
+        #[cfg(test)]
+        self.sanity_check()
     }
 
     pub fn len(&self) -> usize {
@@ -433,6 +436,22 @@ impl Instruction {
             Machine::Pic(_) => 1,
             // In case of unknown instruction length, assume 1 so that optimizer still works
             _ => 1,
+        }
+    }
+
+    #[cfg(test)]
+    pub fn sanity_check(&self) {
+        match self.operation {
+            Operation::Monadic(_, _, _, Datum::Imm8(_)) => {
+                panic!("The instruction has an immediate destination");
+            }
+            Operation::Dyadic(_, _, _, _, Datum::Imm8(_)) => {
+                panic!("The instruction has an immediate destination");
+            }
+            Operation::Move(_, Datum::Imm8(_)) => {
+                panic!("The instruction has an immediate destination");
+            }
+            _ => {}
         }
     }
 

--- a/src/machine.rs
+++ b/src/machine.rs
@@ -265,24 +265,11 @@ mod tests {
     }
 
     #[test]
-    fn disassembler_6800() {
-        disasm(Machine::Motorola6800(Motorola8BitVariant::Motorola6800));
-        disasm(Machine::Motorola6800(Motorola8BitVariant::Motorola6801));
-    }
-
-    #[test]
     fn disassembler_prex86() {
         disasm(Machine::PreX86(PreX86Variant::ZilogZ80));
         disasm(Machine::PreX86(PreX86Variant::I8080));
         disasm(Machine::PreX86(PreX86Variant::Sm83));
         disasm(Machine::PreX86(PreX86Variant::KR580VM1));
-    }
-
-    #[test]
-    fn disassembler_pic() {
-        disasm(Machine::Pic(PicVariant::Pic12));
-        disasm(Machine::Pic(PicVariant::Pic14));
-        disasm(Machine::Pic(PicVariant::Pic16));
     }
 }
 

--- a/src/machine.rs
+++ b/src/machine.rs
@@ -640,49 +640,6 @@ impl Instruction {
                 FlowControl::FallThrough
             }
 
-            Operation::Increment(register) => {
-                match register.width() {
-                    Width::Width8 => {
-                        let (result, _c, z, n, _o, _h) =
-                            add_to_reg8(s.get_i8(register), Some(1), Some(false));
-                        s.set_i8(register, result);
-                        s.zero = z;
-                        s.sign = n;
-                    }
-                    Width::Width16 => {
-                        let (result, _c, z, n, _o, _h) =
-                            add_to_reg16(s.get_i16(register), Some(1), Some(false));
-                        s.set_i16(register, result);
-                        s.zero = z;
-                        s.sign = n;
-                    }
-                }
-                FlowControl::FallThrough
-            }
-
-            Operation::Negate(register) => {
-                let c = s.get_i8(register).map(|x| !x);
-                s.set_i8(register, c);
-                s.zero = c.map(|x| x == 0);
-                FlowControl::FallThrough
-            }
-
-            Operation::Complement(register) => {
-                let c = s.get_i8(register).map(|x| 0 - x);
-                s.set_i8(register, c);
-                s.zero = c.map(|x| x == 0);
-                FlowControl::FallThrough
-            }
-
-            Operation::Decrement(register) => {
-                let (result, _c, z, n, _o, _h) =
-                    add_to_reg8(s.get_i8(register), Some(-1), Some(false));
-                s.set_i8(register, result);
-                s.zero = z;
-                s.sign = n;
-                FlowControl::FallThrough
-            }
-
             Operation::Shift(shtype, datum) => match shtype {
                 ShiftType::LeftArithmetic => {
                     let (val, c) = rotate_left_thru_carry(s.get_i8(datum), Some(false));

--- a/src/machine.rs
+++ b/src/machine.rs
@@ -61,6 +61,7 @@ pub struct Instruction {
     machine: Machine,
 }
 
+#[derive(Clone, Copy, Debug)]
 pub enum Width {
     Width8,
     Width16,
@@ -462,13 +463,16 @@ pub enum Test {
     Bit(u16, u8, bool),
 }
 
+#[derive(Copy, Debug, Clone, PartialEq)]
+pub enum MonadicOperation {
+    Complement, Decrement, Increment, Negate, 
+    // TODO: Move the shifts here.
+}
+
 #[derive(Clone, Debug, Copy)]
 pub enum Operation {
+    Monadic(Width, MonadicOperation, Datum, Datum),
     DecimalAdjustAccumulator,
-    Negate(Datum),
-    Complement(Datum),
-    Decrement(Datum),
-    Increment(Datum),
     Add(Datum, Datum, bool),
     BitCompare(Datum, Datum),
     Compare(Datum, Datum),

--- a/src/machine.rs
+++ b/src/machine.rs
@@ -206,7 +206,6 @@ pub fn bitwise_or(reg: Option<i8>, a: Option<i8>) -> (Option<i8>, Option<bool>) 
     (None, None)
 }
 
-#[allow(clippy::many_single_char_names, clippy::type_complexity)]
 pub fn add_to_reg16(
     reg: Option<i16>,
     a: Option<i16>,
@@ -242,7 +241,6 @@ pub fn add_to_reg16(
     }
 }
 
-#[allow(clippy::many_single_char_names, clippy::type_complexity)]
 pub fn subtract_reg8(
     reg: Option<i8>,
     a: Option<i8>,
@@ -278,7 +276,6 @@ pub fn subtract_reg8(
     }
 }
 
-#[allow(clippy::many_single_char_names, clippy::type_complexity)]
 pub fn add_to_reg8(
     reg: Option<i8>,
     a: Option<i8>,
@@ -550,7 +547,6 @@ impl Instruction {
         }
     }
 
-    #[allow(clippy::many_single_char_names)]
     pub fn operate(&self, s: &mut State) -> FlowControl {
         match self.operation {
             Operation::Add(source, destination, carry) => {

--- a/src/machine.rs
+++ b/src/machine.rs
@@ -75,7 +75,7 @@ impl std::fmt::Display for Instruction {
     }
 }
 
-#[derive(Copy, Debug, Clone, PartialEq)]
+#[derive(Copy, Debug, Clone, PartialEq, Eq)]
 pub enum R {
     A,
     B,
@@ -92,7 +92,7 @@ pub enum R {
     Yl,
 }
 
-#[derive(Copy, Debug, Clone, PartialEq)]
+#[derive(Copy, Debug, Clone, PartialEq, Eq)]
 pub enum Datum {
     Register(R),
     RegisterPair(R, R),
@@ -511,6 +511,8 @@ impl DyadicOperation {
                     }
                 }
                 Self::And => Some(a & b),
+                Self::Or => Some(a | b),
+                Self::ExclusiveOr => Some(a ^ b),
             }
         } else {
             None
@@ -523,7 +525,6 @@ pub enum Operation {
     Monadic(Width, MonadicOperation, Datum, Datum),
     Dyadic(Width, DyadicOperation, Datum, Datum, Datum),
     DecimalAdjustAccumulator,
-    Add(Datum, Datum, bool),
     BitCompare(Datum, Datum),
     Compare(Datum, Datum),
     Move(Datum, Datum),

--- a/src/machine.rs
+++ b/src/machine.rs
@@ -190,59 +190,6 @@ pub fn bitwise_and(reg: Option<i8>, a: Option<i8>) -> (Option<i8>, Option<bool>)
     (None, None)
 }
 
-pub fn bitwise_xor(reg: Option<i8>, a: Option<i8>) -> (Option<i8>, Option<bool>) {
-    if let Some(operand) = a {
-        if let Some(r) = reg {
-            return (Some(r ^ operand), Some(r ^ operand == 0));
-        }
-    }
-    (None, None)
-}
-
-pub fn bitwise_or(reg: Option<i8>, a: Option<i8>) -> (Option<i8>, Option<bool>) {
-    if let Some(operand) = a {
-        if let Some(r) = reg {
-            return (Some(r | operand), Some(r | operand == 0));
-        }
-    }
-    (None, None)
-}
-
-pub fn add_to_reg16(
-    reg: Option<i16>,
-    a: Option<i16>,
-    carry: Option<bool>,
-) -> (
-    Option<i16>,
-    Option<bool>,
-    Option<bool>,
-    Option<bool>,
-    Option<bool>,
-    Option<bool>,
-) {
-    // The return values are the result of the addition, then the flags, carry, zero, sign, overflow, half-carry.
-    if let Some(operand) = a {
-        if let Some(r) = reg {
-            if let Some(c) = carry {
-                let v = operand.wrapping_add(if c { 1 } else { 0 });
-                let result = r.wrapping_add(v);
-                let z = result == 0;
-                let c = r.checked_add(v).is_none();
-                let n = result < 0;
-                let o = (r < 0 && v < 0 && result >= 0) || (r > 0 && v > 0 && result <= 0);
-                let h = ((r ^ v ^ result) & 0x10) == 0x10;
-                (Some(result), Some(c), Some(z), Some(n), Some(o), Some(h))
-            } else {
-                (None, None, None, None, None, None)
-            }
-        } else {
-            (None, None, None, None, None, None)
-        }
-    } else {
-        (None, None, None, None, None, None)
-    }
-}
-
 pub fn subtract_reg8(
     reg: Option<i8>,
     a: Option<i8>,
@@ -263,41 +210,6 @@ pub fn subtract_reg8(
                 let result = r.wrapping_sub(v);
                 let z = result == 0;
                 let c = r.checked_sub(v).is_none();
-                let n = result < 0;
-                let o = (r < 0 && v < 0 && result >= 0) || (r > 0 && v > 0 && result <= 0);
-                let h = ((r ^ v ^ result) & 0x10) == 0x10;
-                (Some(result), Some(c), Some(z), Some(n), Some(o), Some(h))
-            } else {
-                (None, None, None, None, None, None)
-            }
-        } else {
-            (None, None, None, None, None, None)
-        }
-    } else {
-        (None, None, None, None, None, None)
-    }
-}
-
-pub fn add_to_reg8(
-    reg: Option<i8>,
-    a: Option<i8>,
-    carry: Option<bool>,
-) -> (
-    Option<i8>,
-    Option<bool>,
-    Option<bool>,
-    Option<bool>,
-    Option<bool>,
-    Option<bool>,
-) {
-    // The return values are the result of the addition, then the flags, carry, zero, sign, overflow, half-carry.
-    if let Some(operand) = a {
-        if let Some(r) = reg {
-            if let Some(c) = carry {
-                let v = operand.wrapping_add(if c { 1 } else { 0 });
-                let result = r.wrapping_add(v);
-                let z = result == 0;
-                let c = r.checked_add(v).is_none();
                 let n = result < 0;
                 let o = (r < 0 && v < 0 && result >= 0) || (r > 0 && v > 0 && result <= 0);
                 let h = ((r ^ v ^ result) & 0x10) == 0x10;

--- a/src/machine.rs
+++ b/src/machine.rs
@@ -616,7 +616,6 @@ pub struct State {
     zero: Option<bool>,
     carry: Option<bool>,
     sign: Option<bool>,
-    overflow: Option<bool>,
     halfcarry: Option<bool>,
     heap: HashMap<u16, Option<i8>>,
 }
@@ -640,7 +639,6 @@ impl State {
             zero: None,
             carry: None,
             sign: None,
-            overflow: None,
             halfcarry: None,
             heap: HashMap::new(),
         }

--- a/src/machine.rs
+++ b/src/machine.rs
@@ -415,13 +415,8 @@ impl DyadicOperation {
         if let (Some(a), Some(b)) = (a, b) {
             match self {
                 Self::Add => Some(a.wrapping_add(&b)),
-                Self::AddWithCarry => {
-                    if let Some(c) = s.carry {
-                        Some(a.wrapping_add(&b).wrapping_add(if c { one } else { zero }))
-                    } else {
-                        None
-                    }
-                }
+                Self::AddWithCarry => 
+                    s.carry.map(|c| a.wrapping_add(&b).wrapping_add(if c { one } else { zero })),
                 Self::And => Some(a & b),
                 Self::Or => Some(a | b),
                 Self::ExclusiveOr => Some(a ^ b),

--- a/src/machine.rs
+++ b/src/machine.rs
@@ -319,36 +319,6 @@ mod tests {
         disasm(Machine::Pic(PicVariant::Pic14));
         disasm(Machine::Pic(PicVariant::Pic16));
     }
-
-    #[test]
-    fn add_to_reg8_test() {
-        assert_eq!(
-            add_to_reg8(Some(3), Some(3), Some(false)),
-            (
-                Some(6),
-                Some(false),
-                Some(false),
-                Some(false),
-                Some(false),
-                Some(false)
-            )
-        );
-        assert_eq!(
-            add_to_reg8(Some(127), Some(1), Some(false)),
-            (
-                Some(-128),
-                Some(true),
-                Some(false),
-                Some(true),
-                Some(true),
-                Some(true)
-            )
-        );
-        assert_eq!(
-            add_to_reg8(None, Some(3), Some(false)),
-            (None, None, None, None, None, None)
-        );
-    }
 }
 
 #[derive(Clone, Debug, Copy)]
@@ -415,8 +385,9 @@ impl DyadicOperation {
         if let (Some(a), Some(b)) = (a, b) {
             match self {
                 Self::Add => Some(a.wrapping_add(&b)),
-                Self::AddWithCarry => 
-                    s.carry.map(|c| a.wrapping_add(&b).wrapping_add(if c { one } else { zero })),
+                Self::AddWithCarry => s
+                    .carry
+                    .map(|c| a.wrapping_add(&b).wrapping_add(if c { one } else { zero })),
                 Self::And => Some(a & b),
                 Self::Or => Some(a | b),
                 Self::ExclusiveOr => Some(a ^ b),

--- a/src/machine.rs
+++ b/src/machine.rs
@@ -443,13 +443,22 @@ impl Instruction {
     pub fn sanity_check(&self) {
         match self.operation {
             Operation::Monadic(_, _, _, Datum::Imm8(_)) => {
-                panic!("The instruction has an immediate destination");
+                panic!(
+                    "The instruction {:?} has an immediate destination",
+                    self.operation
+                );
             }
             Operation::Dyadic(_, _, _, _, Datum::Imm8(_)) => {
-                panic!("The instruction has an immediate destination");
+                panic!(
+                    "The instruction {:?} has an immediate destination",
+                    self.operation
+                );
             }
             Operation::Move(_, Datum::Imm8(_)) => {
-                panic!("The instruction has an immediate destination");
+                panic!(
+                    "The instruction {:?} has an immediate destination",
+                    self.operation
+                );
             }
             _ => {}
         }

--- a/src/machine.rs
+++ b/src/machine.rs
@@ -621,7 +621,24 @@ impl Instruction {
                 s.accumulator = decimal_adjust(s.accumulator, s.carry, s.halfcarry);
                 FlowControl::FallThrough
             }
-
+            Operation::BitCompare(source, destination) => {
+                let (result, z) = bitwise_and(s.get_i8(source), s.get_i8(destination));
+                if let Some(result) = result {
+                    s.sign = Some(result < 0);
+                } else {
+                    s.sign = None
+                }
+                s.zero = z;
+                FlowControl::FallThrough
+            }
+            Operation::Compare(source, destination) => {
+                let (_result, c, z, n, _o, _h) =
+                    subtract_reg8(s.get_i8(source), s.get_i8(destination), Some(false));
+                s.sign = n;
+                s.carry = c;
+                s.zero = z;
+                FlowControl::FallThrough
+            }
             Operation::Shift(shtype, datum) => match shtype {
                 ShiftType::LeftArithmetic => {
                     let (val, c) = rotate_left_thru_carry(s.get_i8(datum), Some(false));

--- a/src/machine/m6800.rs
+++ b/src/machine/m6800.rs
@@ -159,3 +159,16 @@ pub fn instr_6800(mach: Machine) -> Instruction {
     )
     // TODO: Add clc, sec, daa, and many other instructions
 }
+
+#[cfg(test)]
+mod tests {
+    use crate::machine::tests::disasm;
+    use crate::Machine;
+    use crate::Motorola8BitVariant;
+
+    #[test]
+    fn disassembler() {
+        disasm(Machine::Motorola6800(Motorola8BitVariant::Motorola6800));
+        disasm(Machine::Motorola6800(Motorola8BitVariant::Motorola6801));
+    }
+}

--- a/src/machine/mos6502.rs
+++ b/src/machine/mos6502.rs
@@ -146,7 +146,7 @@ fn incdec_6502(mach: Machine) -> Operation {
         random_xy()
     };
     if random() {
-        Operation::Monadic(Width::Width8, MonadicOperation::Increment, reg, reg)
+        Operation::Monadic(Width::Width8, MonadicOperation::Decrement, reg, reg)
     } else {
         Operation::Monadic(Width::Width8, MonadicOperation::Increment, reg, reg)
     }

--- a/src/machine/mos6502.rs
+++ b/src/machine/mos6502.rs
@@ -3,11 +3,11 @@ use crate::machine::random_immediate;
 use crate::machine::Datum;
 use crate::machine::Instruction;
 use crate::machine::Machine;
+use crate::machine::MonadicOperation;
 use crate::machine::Mos6502Variant;
 use crate::machine::Operation;
 use crate::machine::ShiftType;
 use crate::machine::Width;
-use crate::machine::MonadicOperation;
 use crate::machine::R;
 
 use rand::random;
@@ -62,10 +62,18 @@ fn dasm(op: Operation, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         Operation::Compare(thing, Datum::Register(R::Xl)) => syn(f, "cpx", thing),
         Operation::Compare(thing, Datum::Register(R::Yl)) => syn(f, "cpy", thing),
         Operation::ExclusiveOr(thing, Datum::Register(R::A)) => syn(f, "eor", thing),
-        Operation::Monadic(Width::Width8, MonadicOperation::Increment, Datum::Register(r), _) => write!(f, "\tin{}", regname(r)),
-        Operation::Monadic(Width::Width8, MonadicOperation::Decrement, Datum::Register(r), _) => write!(f, "\tde{}", regname(r)),
-        Operation::Monadic(Width::Width8, MonadicOperation::Increment, dat, _) => syn(f, "inc", dat),
-        Operation::Monadic(Width::Width8, MonadicOperation::Decrement, dat, _) => syn(f, "dec", dat),
+        Operation::Monadic(Width::Width8, MonadicOperation::Increment, Datum::Register(r), _) => {
+            write!(f, "\tin{}", regname(r))
+        }
+        Operation::Monadic(Width::Width8, MonadicOperation::Decrement, Datum::Register(r), _) => {
+            write!(f, "\tde{}", regname(r))
+        }
+        Operation::Monadic(Width::Width8, MonadicOperation::Increment, dat, _) => {
+            syn(f, "inc", dat)
+        }
+        Operation::Monadic(Width::Width8, MonadicOperation::Decrement, dat, _) => {
+            syn(f, "dec", dat)
+        }
         Operation::Carry(false) => write!(f, "\tclc"),
         Operation::Carry(true) => write!(f, "\tsec"),
         _ => {

--- a/src/machine/mos6502.rs
+++ b/src/machine/mos6502.rs
@@ -61,7 +61,9 @@ fn dasm(op: Operation, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         Operation::Shift(ShiftType::RightRotateThroughCarry, thing) => syn(f, "ror", thing),
         Operation::Shift(ShiftType::LeftRotateThroughCarry, thing) => syn(f, "rol", thing),
         Operation::Dyadic(Width::Width8, AddWithCarry, A, thing, A) => syn(f, "adc", thing),
-        Operation::Dyadic(Width::Width8, And, A, thing, A) => syn(f, "adc", thing),
+        Operation::Dyadic(Width::Width8, And, A, thing, A) => syn(f, "and", thing),
+        Operation::Dyadic(Width::Width8, ExclusiveOr, A, thing, A) => syn(f, "eor", thing),
+        Operation::Dyadic(Width::Width8, Or, A, thing, A) => syn(f, "ora", thing),
         Operation::Compare(thing, Datum::Register(R::A)) => syn(f, "cmp", thing),
         Operation::Compare(thing, Datum::Register(R::Xl)) => syn(f, "cpx", thing),
         Operation::Compare(thing, Datum::Register(R::Yl)) => syn(f, "cpy", thing),
@@ -242,9 +244,7 @@ mod tests {
         // TODO: bcc bcs beq bit bmi bne bpl bvc bvs cld clv dec inc jmp ora pha pla sbc sed tsx txs
         // I don't think we need to bother with brk cli jsr nop php plp rti rts sei
         find_it("clc", secl_6502, mach);
-        find_it("cmp", alu_6502, mach);
-        find_it("cpx", alu_6502, mach);
-        find_it("cpy", alu_6502, mach);
+        // Temporarily removed cmp cpx cpy untill I figure out what I want to do with them
         find_it("dex", incdec_6502, mach);
         find_it("dey", incdec_6502, mach);
         find_it("eor", alu_6502, mach);

--- a/src/machine/mos6502.rs
+++ b/src/machine/mos6502.rs
@@ -64,9 +64,6 @@ fn dasm(op: Operation, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         Operation::Dyadic(Width::Width8, And, A, thing, A) => syn(f, "and", thing),
         Operation::Dyadic(Width::Width8, ExclusiveOr, A, thing, A) => syn(f, "eor", thing),
         Operation::Dyadic(Width::Width8, Or, A, thing, A) => syn(f, "ora", thing),
-        Operation::Compare(thing, Datum::Register(R::A)) => syn(f, "cmp", thing),
-        Operation::Compare(thing, Datum::Register(R::Xl)) => syn(f, "cpx", thing),
-        Operation::Compare(thing, Datum::Register(R::Yl)) => syn(f, "cpy", thing),
         Operation::Monadic(Width::Width8, MonadicOperation::Increment, Datum::Register(r), _) => {
             write!(f, "\tin{}", regname(r))
         }
@@ -110,7 +107,6 @@ pub fn instr_length_6502(operation: Operation) -> usize {
         Operation::Shift(_, dat) => length(dat),
         Operation::Monadic(Width::Width8, MonadicOperation::Increment, dat, _) => length(dat),
         Operation::Monadic(Width::Width8, MonadicOperation::Decrement, dat, _) => length(dat),
-        Operation::Compare(dat, _) => length(dat),
         Operation::Dyadic(Width::Width8, _, _, dat, _) => length(dat),
         Operation::Carry(_) => 1,
         _ => 0,

--- a/src/machine/mos6502.rs
+++ b/src/machine/mos6502.rs
@@ -117,7 +117,7 @@ pub fn instr_length_6502(operation: Operation) -> usize {
     }
 }
 
-fn random_source_6502() -> Datum {
+fn random_source() -> Datum {
     if random() {
         random_immediate()
     } else {
@@ -160,7 +160,7 @@ fn alu_6502(_mach: Machine) -> Operation {
     // these all have the same available addressing modes
     let ops = vec![AddWithCarry, And, Or, ExclusiveOr];
     let op = *ops.choose(&mut rand::thread_rng()).unwrap();
-    Operation::Dyadic(Width::Width8, op, A, random_absolute(), A)
+    Operation::Dyadic(Width::Width8, op, A, random_source(), A)
 }
 
 fn transfers_6502(_mach: Machine) -> Operation {

--- a/src/machine/pic.rs
+++ b/src/machine/pic.rs
@@ -180,12 +180,8 @@ mod tests {
                 Operation::Move(Datum::Register(R::A), Datum::Register(R::A)) => {
                     panic!("{} produced a move from W to W", fname)
                 }
-                Operation::Add(Datum::Absolute(_), Datum::Absolute(_), _) => panic!(
+                Operation::Dyadic(_, _, Datum::Absolute(_), Datum::Absolute(_), _) => panic!(
                     "{} produced an Add operation with two operands in memory",
-                    fname
-                ),
-                Operation::And(Datum::Absolute(_), Datum::Absolute(_)) => panic!(
-                    "{} produced an And operation with two operands in memory",
                     fname
                 ),
                 _ => {}

--- a/src/machine/pic.rs
+++ b/src/machine/pic.rs
@@ -58,9 +58,15 @@ fn dasm(op: Operation, fr: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         ) => {
             write!(fr, "\tandlw {}, 0", k)
         }
-        Operation::Dyadic(Width::Width8, Add, W, Datum::Imm8(k), W) => { write!(fr, "\taddlw {}, 0", k) }
-        Operation::Dyadic(Width::Width8, Add, W, Datum::Absolute(f), W) => { write!(fr, "\taddwf {}, 0", f) }
-        Operation::Dyadic(Width::Width8, Add, W, _, Datum::Absolute(f)) => { write!(fr, "\taddwf {}, 1", f) }
+        Operation::Dyadic(Width::Width8, Add, W, Datum::Imm8(k), W) => {
+            write!(fr, "\taddlw {}, 0", k)
+        }
+        Operation::Dyadic(Width::Width8, Add, W, Datum::Absolute(f), W) => {
+            write!(fr, "\taddwf {}, 0", f)
+        }
+        Operation::Dyadic(Width::Width8, Add, W, _, Datum::Absolute(f)) => {
+            write!(fr, "\taddwf {}, 1", f)
+        }
         Operation::Move(Datum::Absolute(f), Datum::Register(R::A)) => {
             write!(fr, "\tmovf {}, 0", f)
         }

--- a/src/machine/pic.rs
+++ b/src/machine/pic.rs
@@ -169,6 +169,7 @@ pub fn instr_pic(mach: Machine) -> Instruction {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::machine::tests::disasm;
 
     #[test]
     fn exclude_instructions() {
@@ -235,5 +236,12 @@ mod tests {
         find_it("movwf", store_pic, PicVariant::Pic14);
         find_it("rlf", shifts_pic, PicVariant::Pic14);
         find_it("rrf", shifts_pic, PicVariant::Pic14);
+    }
+
+    #[test]
+    fn disassembler() {
+        disasm(Machine::Pic(PicVariant::Pic12));
+        disasm(Machine::Pic(PicVariant::Pic14));
+        disasm(Machine::Pic(PicVariant::Pic16));
     }
 }

--- a/src/machine/pic.rs
+++ b/src/machine/pic.rs
@@ -126,9 +126,9 @@ fn store_pic(_mach: Machine) -> Operation {
     // TODO: There also is movf f,d, which just updates the Z flag
     randomly!(
         { Operation::Move(Datum::Zero, random_accumulator_or_absolute())} // clrw and clrf f
-            { Operation::Move(random_absolute(), Datum::Register(R::A))}      // movf f
-                { Operation::Move(random_immediate(), Datum::Register(R::A))}     // movlw k
-                    { Operation::Move(Datum::Register(R::A), random_absolute())}      // movwf f
+        { Operation::Move(random_absolute(), Datum::Register(R::A))}      // movf f
+        { Operation::Move(random_immediate(), Datum::Register(R::A))}     // movlw k
+        { Operation::Move(Datum::Register(R::A), random_absolute())}      // movwf f
     )
 }
 

--- a/src/machine/prex86.rs
+++ b/src/machine/prex86.rs
@@ -162,3 +162,18 @@ pub fn instr_prex86(mach: Machine) -> Instruction {
         { Instruction::new(mach, |_| Operation::DecimalAdjustAccumulator, dasm)}
     )
 }
+
+#[cfg(test)]
+mod tests {
+    use crate::machine::tests::disasm;
+    use crate::Machine;
+    use crate::PreX86Variant;
+
+    #[test]
+    fn disassembler() {
+        disasm(Machine::PreX86(PreX86Variant::ZilogZ80));
+        disasm(Machine::PreX86(PreX86Variant::I8080));
+        disasm(Machine::PreX86(PreX86Variant::Sm83));
+        disasm(Machine::PreX86(PreX86Variant::KR580VM1));
+    }
+}

--- a/src/machine/stm8.rs
+++ b/src/machine/stm8.rs
@@ -276,9 +276,7 @@ fn oneargs(_mach: Machine) -> Operation {
     }
 
     if random() {
-        let a = if random() { A } else { random_immediate() };
-
-        op(Width::Width8, a)
+        op(Width::Width8, A)
     } else {
         let a = if random() { X } else { Y };
 

--- a/src/machine/stm8.rs
+++ b/src/machine/stm8.rs
@@ -351,10 +351,10 @@ mod tests {
         find_it("ccf", carry);
         find_it("clr", clear);
         find_it("clrw", clear);
-        find_it("dec", incdec);
-        find_it("decw", incdec);
-        find_it("inc", incdec);
-        find_it("incw", incdec);
+        find_it("dec", oneargs);
+        find_it("decw", oneargs);
+        find_it("inc", oneargs);
+        find_it("incw", oneargs);
         find_it("jrc", jumps);
         find_it("jrnc", jumps);
         find_it("ld a, xh", transfers);

--- a/src/machine/stm8.rs
+++ b/src/machine/stm8.rs
@@ -178,7 +178,7 @@ fn clear(_mach: Machine) -> Operation {
 
 fn twoargs(_mach: Machine) -> Operation {
     fn op(w: Width, a: Datum) -> Operation {
-        let vs = vec![Add, AddWithCarry];
+        let vs = vec![Add, AddWithCarry, And, Or, ExclusiveOr];
         let o = vs.choose(&mut rand::thread_rng());
         Operation::Dyadic(w, *o.unwrap(), a, random_absolute(), a)
     }
@@ -203,12 +203,6 @@ fn bits(_mach: Machine) -> Operation {
         { Operation::BitComplement(addr, bit)}
         { Operation::BitCopyCarry(addr, bit)}
     )
-}
-
-fn alu8(_mach: Machine) -> Operation {
-    let ops = vec![And, Or, ExclusiveOr];
-    let op = *ops.choose(&mut rand::thread_rng()).unwrap();
-    Operation::Dyadic(Width::Width8, op, random_stm8_operand(), A, A)
 }
 
 fn shifts(_mach: Machine) -> Operation {
@@ -288,7 +282,6 @@ pub fn instr_stm8(mach: Machine) -> Instruction {
     randomly!(
     { Instruction::new(mach, clear, dasm)}
     { Instruction::new(mach, transfers, dasm)}
-    { Instruction::new(mach, alu8, dasm)}
     { Instruction::new(mach, bits, dasm)}
     { Instruction::new(mach, carry, dasm)}
     { Instruction::new(mach, compare, dasm)}
@@ -328,7 +321,7 @@ mod tests {
         find_it("adc", twoargs);
         find_it("add", twoargs);
         find_it("addw", twoargs);
-        find_it("and", alu8);
+        find_it("and", twoargs);
         find_it("bccm", bits);
         find_it("bcp", compare);
         find_it("btjf", jumps);
@@ -351,7 +344,7 @@ mod tests {
         find_it("ld yl, a", transfers);
         find_it("neg", oneargs);
         find_it("negw", oneargs);
-        find_it("or", alu8);
+        find_it("or", twoargs);
         find_it("rcf", carry);
         find_it("scf", carry);
         find_it("rlc", shifts);
@@ -360,6 +353,6 @@ mod tests {
         find_it("rrcw", shifts);
         find_it("sla", shifts);
         find_it("slaw", shifts);
-        find_it("xor", alu8);
+        find_it("xor", twoargs);
     }
 }

--- a/src/machine/stm8.rs
+++ b/src/machine/stm8.rs
@@ -340,8 +340,6 @@ mod tests {
         find_it("bres", bits);
         find_it("cpl", oneargs);
         find_it("cplw", oneargs);
-        find_it("cp", compare);
-        find_it("cpw", compare);
         find_it("ccf", carry);
         find_it("clr", clear);
         find_it("clrw", clear);

--- a/src/machine/stm8.rs
+++ b/src/machine/stm8.rs
@@ -17,6 +17,8 @@ use crate::machine::rand::Rng;
 use rand::random;
 use strop::randomly;
 
+const A: Datum = Datum::Register(R::A);
+
 fn random_stm8_operand() -> Datum {
     if random() {
         random_immediate()
@@ -61,7 +63,7 @@ fn dasm(op: Operation, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
             Datum::Register(R::A) => ("", "a"),
             Datum::RegisterPair(R::Xh, R::Xl) => ("w", "x"),
             Datum::RegisterPair(R::Yh, R::Yl) => ("w", "y"),
-            _ => panic!(),
+            _ => panic!("dsyn baulks at {:?} for r", r),
         };
 
         match d {
@@ -123,11 +125,11 @@ fn dasm(op: Operation, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
     match op {
         Operation::Compare(d, r) => dsyn(f, "cp", r, d),
         Operation::BitCompare(d, r) => dsyn(f, "bcp", r, d),
-        Operation::Dyadic(_, And, d, r, _) => dsyn(f, "and", r, d),
-        Operation::Dyadic(_, Add, d, r, _) => dsyn(f, "add", r, d),
-        Operation::Dyadic(_, AddWithCarry, d, r, _) => dsyn(f, "adc", r, d),
-        Operation::Dyadic(_, Or, d, r, _) => dsyn(f, "or", r, d),
-        Operation::Dyadic(_, ExclusiveOr, d, r, _) => dsyn(f, "xor", r, d),
+        Operation::Dyadic(_, And, _, d, r) => dsyn(f, "and", r, d),
+        Operation::Dyadic(_, Add, _, d, r) => dsyn(f, "add", r, d),
+        Operation::Dyadic(_, AddWithCarry, _, d, r) => dsyn(f, "adc", r, d),
+        Operation::Dyadic(_, Or, _, d, r) => dsyn(f, "or", r, d),
+        Operation::Dyadic(_, ExclusiveOr, _, d, r) => dsyn(f, "xor", r, d),
         Operation::Shift(ShiftType::LeftRotateThroughCarry, d) => syn(f, "rlc", d),
         Operation::Shift(ShiftType::RightRotateThroughCarry, d) => syn(f, "rrc", d),
         Operation::Shift(ShiftType::LeftArithmetic, d) => syn(f, "sla", d),
@@ -182,13 +184,7 @@ fn twoargs(_mach: Machine) -> Operation {
     }
 
     if random() {
-        let a = if random() {
-            Datum::Register(R::A)
-        } else {
-            random_immediate()
-        };
-
-        op(Width::Width8, a)
+        op(Width::Width8, A)
     } else {
         let a = if random() {
             Datum::RegisterPair(R::Xh, R::Xl)

--- a/src/machine/stm8.rs
+++ b/src/machine/stm8.rs
@@ -187,11 +187,7 @@ fn twoargs(_mach: Machine) -> Operation {
     if random() {
         op(Width::Width8, A)
     } else {
-        let a = if random() {
-            X
-        } else {
-            Y
-        };
+        let a = if random() { X } else { Y };
 
         op(Width::Width16, a)
     }
@@ -213,13 +209,7 @@ fn bits(_mach: Machine) -> Operation {
 fn alu8(_mach: Machine) -> Operation {
     let ops = vec![And, Or, ExclusiveOr];
     let op = *ops.choose(&mut rand::thread_rng()).unwrap();
-    Operation::Dyadic(
-        Width::Width8,
-        op,
-        random_stm8_operand(),
-        A,
-        A,
-    )
+    Operation::Dyadic(Width::Width8, op, random_stm8_operand(), A, A)
 }
 
 fn shifts(_mach: Machine) -> Operation {
@@ -292,19 +282,11 @@ fn oneargs(_mach: Machine) -> Operation {
     }
 
     if random() {
-        let a = if random() {
-            A
-        } else {
-            random_immediate()
-        };
+        let a = if random() { A } else { random_immediate() };
 
         op(Width::Width8, a)
     } else {
-        let a = if random() {
-            X
-        } else {
-            Y
-        };
+        let a = if random() { X } else { Y };
 
         op(Width::Width16, a)
     }

--- a/src/machine/stm8.rs
+++ b/src/machine/stm8.rs
@@ -359,9 +359,9 @@ mod tests {
         // I don't think we need call callf callr halt iret jrf jrih jril jrm nop ret retf rim sim trap wfe wfi
         // TODO: div divw exg exgw ld ldw mov mul pop popw push pushw rvf sbc sub subw swap tnz tnzw
         // TODO: conditional jumps, relative jump, more shifts
-        find_it("adc", add_adc);
-        find_it("add", add_adc);
-        find_it("addw", add_adc);
+        find_it("adc", twoargs);
+        find_it("add", twoargs);
+        find_it("addw", twoargs);
         find_it("and", alu8);
         find_it("bccm", bits);
         find_it("bcp", compare);

--- a/src/machine/stm8.rs
+++ b/src/machine/stm8.rs
@@ -124,7 +124,6 @@ fn dasm(op: Operation, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
     }
 
     match op {
-        Operation::Compare(d, r) => dsyn(f, "cp", r, d),
         Operation::BitCompare(d, r) => dsyn(f, "bcp", r, d),
         Operation::Dyadic(_, And, _, d, r) => dsyn(f, "and", r, d),
         Operation::Dyadic(_, Add, _, d, r) => dsyn(f, "add", r, d),
@@ -238,12 +237,7 @@ fn carry(_mach: Machine) -> Operation {
 }
 
 fn compare(_mach: Machine) -> Operation {
-    randomly!(
-        { Operation::Compare(random_stm8_operand(), A)}
-        { Operation::Compare(random_stm8_operand(), X)}
-        { Operation::Compare(random_stm8_operand(), Y)}
-        { Operation::BitCompare(random_stm8_operand(), A)}
-    )
+    Operation::BitCompare(random_stm8_operand(), A)
 }
 
 fn transfers(_mach: Machine) -> Operation {

--- a/src/machine/stm8.rs
+++ b/src/machine/stm8.rs
@@ -318,6 +318,13 @@ mod tests {
         // I don't think we need call callf callr halt iret jrf jrih jril jrm nop ret retf rim sim trap wfe wfi
         // TODO: div divw exg exgw ld ldw mov mul pop popw push pushw rvf sbc sub subw swap tnz tnzw
         // TODO: conditional jumps, relative jump, more shifts
+        //
+        // rvf could maybe be grouped up along with rcf and scf
+        // pop, popw, push, pushw, need to think about how to implement a stack
+        // ld, ldw, mov probably fit in Move
+        // exg, exgw, sbc, sub, subw probably fit in Dyadic
+        // swap, tnz, tnzw, more shifts will fit in Monadic
+        // div, divw, mul might need their own or go in with Dyadic
         find_it("adc", twoargs);
         find_it("add", twoargs);
         find_it("addw", twoargs);


### PR DESCRIPTION
There is a mahusive enum that defines all possible operations.

It's inflexible, it's inelegant, it's ugly.

So we're going to break the Operations enum out to variants like ConditionalBranch, DyadicAluOperation, MonadicOperations etc, and these variants will be:

- much more easily randomized and dealt with in the various places.
- lend themselves to use of code deduplication by use of generics
- easier to work with

This work (not strictly a refactor) will also enable the completion of some of the TODOs that there are. 