### PR TITLE
Trait

### DIFF
--- a/examples/multiply_accumulator_by_constant/src/main.rs
+++ b/examples/multiply_accumulator_by_constant/src/main.rs
@@ -21,9 +21,6 @@ struct MultiplyByConstant {
 }
 
 impl Search<Instruction6502> for MultiplyByConstant {
-    fn optimize(&self, bb: &BasicBlock<Instruction6502>) -> f64 {
-        bb.len() as f64
-    }
 
     fn correctitude(&self, bb: &BasicBlock<Instruction6502>) -> f64 {
         let factor = self.constant;

--- a/examples/multiply_accumulator_by_constant/src/main.rs
+++ b/examples/multiply_accumulator_by_constant/src/main.rs
@@ -1,57 +1,58 @@
 use argh::FromArgs;
-use strop::Search;
-use strop::search::BasicBlock;
-use strop::search::stochastic_search;
-use strop::machine::mos6502::{Mos6502, Instruction6502};
 use rand::random;
+use strop::machine::mos6502::{Instruction6502, Mos6502};
+use strop::search::stochastic_search;
+use strop::search::BasicBlock;
+use strop::Search;
 
 #[derive(FromArgs)]
 /// multiplies the accumulator by a constant
 struct Cli {
     /// turn verbose on
-    #[argh(switch, short='v')]
+    #[argh(switch, short = 'v')]
     verbose: bool,
 
-    #[argh(positional, description="multiply by this number")]
+    #[argh(positional, description = "multiply by this number")]
     multiply_by: u8,
 }
 
 struct MultiplyByConstant {
-    constant: u8
+    constant: u8,
 }
 
 impl Search<Instruction6502> for MultiplyByConstant {
-
-    fn optimize(&self, bb: &BasicBlock<Instruction6502>) -> f64 { bb.len() as f64 }
-
-fn correctitude(&self, bb: &BasicBlock<Instruction6502>) -> f64 {
-    let factor = self.constant;
-    use strop::machine::Instruction;
-
-    let mut state: Mos6502 = Default::default();
-    let mut error: f64 = 0.0;
-
-    for _i in 0..1000 {
-        let input: u8 = random();
-        if let Some(result) = input.checked_mul(factor) {
-            state.carry = Some(false);
-            state.decimal = Some(false);
-            state.a = Some(input);
-
-            for insn in &bb.instructions {
-                insn.operate(&mut state);
-            }
-            
-            if let Some(a) = state.a {
-                error += (f64::from(a) - f64::from(result)).abs();
-            } else {
-                error += 1000.0;
-            }
-        }
+    fn optimize(&self, bb: &BasicBlock<Instruction6502>) -> f64 {
+        bb.len() as f64
     }
 
-    error
-}
+    fn correctitude(&self, bb: &BasicBlock<Instruction6502>) -> f64 {
+        let factor = self.constant;
+        use strop::machine::Instruction;
+
+        let mut state: Mos6502 = Default::default();
+        let mut error: f64 = 0.0;
+
+        for _i in 0..1000 {
+            let input: u8 = random();
+            if let Some(result) = input.checked_mul(factor) {
+                state.carry = Some(false);
+                state.decimal = Some(false);
+                state.a = Some(input);
+
+                for insn in &bb.instructions {
+                    insn.operate(&mut state);
+                }
+
+                if let Some(a) = state.a {
+                    error += (f64::from(a) - f64::from(result)).abs();
+                } else {
+                    error += 1000.0;
+                }
+            }
+        }
+
+        error
+    }
 }
 
 fn main() {
@@ -61,7 +62,9 @@ fn main() {
         println!("A program to multiply by {}", cli.multiply_by);
     }
 
-    let mul = MultiplyByConstant { constant: cli.multiply_by };
+    let mul = MultiplyByConstant {
+        constant: cli.multiply_by,
+    };
 
     let prog = stochastic_search(mul);
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -16,9 +16,15 @@ use search::BasicBlock;
 
 pub use rand;
 
+/// Implement this trait to define and constrain the search space.
 pub trait Search<I: machine::Instruction> {
+    /// Used to determine how "correct" a proposed program is (the return value 0 means, the
+    /// program is correct, and the higher the return value, the more wrong the program is.)
+    /// `stochastic_search` will halt when this function returns zero.
     fn correctitude(&self, prog: &BasicBlock<I>) -> f64;
 
+    /// Default implementation of `optimize`. This implementation biases the search toward shorter
+    /// programs, and so optimizes for size.
     fn optimize(&self, prog: &BasicBlock<I>) -> f64 {
         prog.instructions
             .iter()

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -32,6 +32,14 @@ pub trait Search<I: machine::Instruction> {
             .sum::<u32>()
             .into()
     }
+
+    /// Default implementation of `okay`. This implementation just returns True, which enables all
+    /// instructions. I would expect end-users will want to use this to disqualify certain classes
+    /// of instructions, such as those requiring specific hardware, or perhaps conditional
+    /// branches, return-from-interrupt and the like.
+    fn okay(&self, _: &I) -> bool {
+        true
+    }
 }
 
 // The reason I can't pull in randomly! as a dependency is that crates.io seems to require all my

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -12,7 +12,14 @@
 pub mod machine;
 pub mod search;
 
+use search::BasicBlock;
+
 pub use rand;
+
+pub trait Search<I: machine::Instruction> {
+    fn correctitude(&self, prog: &BasicBlock<I>) -> f64;
+    fn optimize(&self, prog: &BasicBlock<I>) -> f64;
+}
 
 // The reason I can't pull in randomly! as a dependency is that crates.io seems to require all my
 // dependencies to also be on crates.io.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -18,7 +18,14 @@ pub use rand;
 
 pub trait Search<I: machine::Instruction> {
     fn correctitude(&self, prog: &BasicBlock<I>) -> f64;
-    fn optimize(&self, prog: &BasicBlock<I>) -> f64;
+
+    fn optimize(&self, prog: &BasicBlock<I>) -> f64 {
+        prog.instructions
+            .iter()
+            .map(|i| i.length() as u32)
+            .sum::<u32>()
+            .into()
+    }
 }
 
 // The reason I can't pull in randomly! as a dependency is that crates.io seems to require all my

--- a/src/machine/stm8.rs
+++ b/src/machine/stm8.rs
@@ -997,10 +997,7 @@ const RLC: Stm8Instruction = Stm8Instruction {
     handler: |insn, s| {
         let val = insn.operand.get_rmw().get_u8(s);
         let r = val
-            .map(|v| {
-                s.carry
-                    .map(|c| (v & 0x7f).rotate_left(1) | u8::from(c))
-            })
+            .map(|v| s.carry.map(|c| (v & 0x7f).rotate_left(1) | u8::from(c)))
             .unwrap_or(None);
         s.carry = val.map(|v| v.leading_zeros() == 0);
         s.zero = r.map(|r| r == 0);
@@ -1016,10 +1013,7 @@ const RLCW: Stm8Instruction = Stm8Instruction {
     handler: |insn, s| {
         let val = insn.operand.get_r16().get_u16(s);
         let r = val
-            .map(|v| {
-                s.carry
-                    .map(|c| (v & 0x7fff).rotate_left(1) | u16::from(c))
-            })
+            .map(|v| s.carry.map(|c| (v & 0x7fff).rotate_left(1) | u16::from(c)))
             .unwrap_or(None);
         s.carry = val.map(|v| v.leading_zeros() == 0);
         s.zero = r.map(|r| r == 0);

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,3 +1,0 @@
-fn main() {
-    println!("Hello, World!");
-}

--- a/src/search.rs
+++ b/src/search.rs
@@ -1,9 +1,9 @@
 //! The `search` module provides conveniences for searching for the target
 //! sequence.
 
-use crate::Search;
 use crate::machine::Instruction;
 use crate::randomly;
+use crate::Search;
 use rand::{thread_rng, Rng};
 use std::ops::{Index, IndexMut};
 
@@ -137,8 +137,7 @@ fn mutate<I: Instruction>(prog: &mut BasicBlock<I>) {
 
 /// Search for a basic block. Supply this function with a cost function; `stochastic_search` will
 /// halt when the cost function returns zero.
-pub fn stochastic_search<I: Instruction + Clone>(search: impl Search<I>) -> BasicBlock<I>
-{
+pub fn stochastic_search<I: Instruction + Clone>(search: impl Search<I>) -> BasicBlock<I> {
     let mut population: Vec<(f64, BasicBlock<I>)> = vec![];
     let mut winners: Vec<BasicBlock<I>> = vec![];
 


### PR DESCRIPTION
Instead of handing a single closure to the search function, we should hand in a (reference to) an object which `impl`s a suitable trait. 

Would make for a neater and more extensible API