### PR TITLE
add a bruteforce trait

### DIFF
--- a/examples/emutest65.rs
+++ b/examples/emutest65.rs
@@ -1,5 +1,5 @@
 use strop::mos6502::instruction_set::Nmos6502Instruction;
-use strop::BruteForceSearch;
+use strop::Bruteforce;
 use strop::Emulator;
 use strop::SearchAlgorithm;
 
@@ -15,7 +15,7 @@ fn main() {
     println!("emulators. This is intended to find bugs in the third-party emulators and in");
     println!("the static analysis passes that strop also includes.");
 
-    let mut bruteforce = BruteForceSearch::<Nmos6502Instruction>::new().compatibility(SafeBet);
+    let mut bruteforce = Nmos6502Instruction::bruteforce_search().compatibility(SafeBet);
     for candidate in bruteforce.iter() {
         let mut mos6502 = strop::mos6502::emulators::Mos6502::default();
         let mut nmos6502 = strop::robo6502::emulators::Nmos6502::default();

--- a/examples/library.rs
+++ b/examples/library.rs
@@ -20,8 +20,13 @@ fn stochastic_search(label: &'static str, func: fn(i32, i32) -> Option<i32>) {
     use strop::armv4t::ThumbSearch;
     use strop::Stochastic;
 
-    //let p= Thumb::stochastic_search().aapcs32(func).iter().next().unwrap();
-    let p = <StochasticSearch<Thumb> as ThumbSearch<S>>::aapcs32(Thumb::stochastic_search(), func);
+    let p = <StochasticSearch<Thumb> as ThumbSearch<StochasticSearch<Thumb>>>::aapcs32(
+        Thumb::stochastic_search(),
+        func,
+    )
+    .iter()
+    .next()
+    .unwrap();
 
     println!("{}:", label);
     p.disassemble();

--- a/src/armv4t/instruction_set.rs
+++ b/src/armv4t/instruction_set.rs
@@ -1,8 +1,6 @@
 //!  Two instruction sets supported by the ARMv4T.
 
 use crate::Instruction;
-use crate::Stochastic;
-use crate::StochasticSearch;
 
 /// Type representing the Thumb instruction (no Thumb2 instructions are present here. It's just the
 /// first, fixed-width version).
@@ -13,11 +11,8 @@ pub struct Thumb(pub u16);
 #[derive(Clone, Copy, Debug, PartialEq, PartialOrd)]
 pub struct Arm(pub u32);
 
-impl Stochastic for Thumb {
-    fn stochastic_search() -> StochasticSearch<Self> {
-        StochasticSearch::<Self>::new()
-    }
-}
+impl crate::Stochastic for Thumb {}
+impl crate::Bruteforce for Thumb {}
 
 impl Instruction for Thumb {
     fn random() -> Self {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -42,7 +42,9 @@ use std::convert::TryInto;
 /// Trait enabling a stochastic search over instruction sequences
 pub trait Stochastic: Instruction {
     /// Builds a [StochasticSearch] object for the given instruction set
-    fn stochastic_search() -> StochasticSearch<Self>;
+    fn stochastic_search() -> StochasticSearch<Self> {
+        StochasticSearch::<Self>::new()
+    }
 }
 
 /// Trait enabling an exhaustive search over instruction sequences

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -45,6 +45,14 @@ pub trait Stochastic: Instruction {
     fn stochastic_search() -> StochasticSearch<Self>;
 }
 
+/// Trait enabling an exhaustive search over instruction sequences
+pub trait Bruteforce: Instruction + PartialOrd {
+    /// Builds a [StochasticSearch] object for the given instruction set
+    fn bruteforce_search() -> BruteForceSearch<Self> {
+        BruteForceSearch::<Self>::new()
+    }
+}
+
 /// Type used to feed back to the SearchAlgorithms. The search algorithms are made to react to this
 /// to cull the search space by disallowing certain instructions, and to make sure that generated
 /// programs pass static analysis passes.

--- a/src/mos6502/mod.rs
+++ b/src/mos6502/mod.rs
@@ -8,6 +8,11 @@ use crate::mos6502::instruction_set::Nmos6502Instruction;
 use crate::Compatibility;
 use crate::SearchCull;
 
+impl crate::Bruteforce for Nmos6502Instruction {}
+impl crate::Bruteforce for Cmos6502Instruction {}
+impl crate::Stochastic for Nmos6502Instruction {}
+impl crate::Stochastic for Cmos6502Instruction {}
+
 struct RevisionA;
 
 fn nmos_skip_jump_bug(instruction: &Nmos6502Instruction) -> SearchCull<Nmos6502Instruction> {

--- a/src/z80/instruction_set.rs
+++ b/src/z80/instruction_set.rs
@@ -1,8 +1,6 @@
 //! Module containing definitions for Z80 and 8080 instruction sets
 
 use crate::Instruction;
-use crate::Stochastic;
-use crate::StochasticSearch;
 
 /// Represents a Z80 instruction
 #[derive(Clone, Copy, PartialEq, PartialOrd)]
@@ -10,11 +8,8 @@ pub struct Z80Instruction {
     mc: [u8; 5],
 }
 
-impl Stochastic for Z80Instruction {
-    fn stochastic_search() -> StochasticSearch<Self> {
-        StochasticSearch::<Self>::new()
-    }
-}
+impl crate::Stochastic for Z80Instruction {}
+impl crate::Bruteforce for Z80Instruction {}
 
 impl std::fmt::Debug for Z80Instruction {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> Result<(), std::fmt::Error> {


### PR DESCRIPTION
There's a trait for creating stochastic searches, but no trait for creating bruteforce searches. This fixes that problem.