### PR TITLE
Fix the badges on the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # strop
-[![Build Status](https://github.com/omarandlorraine/strop/workflows/Rust/badge.svg)](https://github.com/omarandlorraine/strop/actions?workflow=Rust)
+[![Build Status](https://github.com/omarandlorraine/strop/workflows/Rust/badge.svg?event=push)](https://github.com/omarandlorraine/strop/actions?workflow=Rust)
 [![crates.io](https://img.shields.io/crates/v/strop)](https://crates.io/crates/strop)
 
 strop, the *st*ochastic *op*timizer, written in *R*ust.
@@ -18,16 +18,16 @@ search or a brute-force search.
 Strop currently has the following back-ends:
 
  * **armv4t**, which targets the ARMv4T processors, such as the ARM7TDMI
-    * [![Build Status](https://github.com/omarandlorraine/strop/workflows/armv4t/badge.svg)](https://github.com/omarandlorraine/strop/actions?workflow=armv4t)
+    * [![Build Status](https://github.com/omarandlorraine/strop/workflows/armv4t/badge.svg?event=push)](https://github.com/omarandlorraine/strop/actions?workflow=armv4t)
  * **m68000**, which targets the Motorola 68000
-    * [![Build Status](https://github.com/omarandlorraine/strop/workflows/m68000/badge.svg)](https://github.com/omarandlorraine/strop/actions?workflow=m68000)
+    * [![Build Status](https://github.com/omarandlorraine/strop/workflows/m68000/badge.svg?event=push)](https://github.com/omarandlorraine/strop/actions?workflow=m68000)
     * NB. This back-end is gated by the `m68k` feature since it requires nightly Rust
  * **m6502**, targets various models of the MOS 6502
-    * [![Build Status](https://github.com/omarandlorraine/strop/workflows/mos6502/badge.svg)](https://github.com/omarandlorraine/strop/actions?workflow=mos6502)
+    * [![Build Status](https://github.com/omarandlorraine/strop/workflows/mos6502/badge.svg?event=push)](https://github.com/omarandlorraine/strop/actions?workflow=mos6502)
     * Supports the NMOS and CMOS variants and others, thanks to the
       [mos6502](https://github.com/mre/mos6502) dependency.
  * **m6809**, which targets the Motorola 6809
-    * [![Build Status](https://github.com/omarandlorraine/strop/workflows/m6809/badge.svg)](https://github.com/omarandlorraine/strop/actions?workflow=m6809)
+    * [![Build Status](https://github.com/omarandlorraine/strop/workflows/m6809/badge.svg?event=push)](https://github.com/omarandlorraine/strop/actions?workflow=m6809)
  * **z80**, which targets the Zilog Z80
-    * [![Build Status](https://github.com/omarandlorraine/strop/workflows/z80/badge.svg)](https://github.com/omarandlorraine/strop/actions?workflow=z80)
+    * [![Build Status](https://github.com/omarandlorraine/strop/workflows/z80/badge.svg?event=push)](https://github.com/omarandlorraine/strop/actions?workflow=z80)
 


### PR DESCRIPTION
the README currently shows failing badges if a feature branch has failing workflows. This PR tries to fix that