### PR TITLE
remove Motorola 6809 "support"

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,10 +9,9 @@ repository = "https://github.com/omarandlorraine/strop"
 homepage = "https://github.com/omarandlorraine/strop"
 
 [features]
-default = ["armv4t", "m6502", "m6809", "z80", "mips", "sm83", "i8080"]
+default = ["armv4t", "m6502", "z80", "mips", "sm83", "i8080"]
 armv4t = ["armv4t_emu", "unarm"]
 m6502 = ["mos6502"]
-m6809 = ["emu6809"]
 z80 = ["iz80", "dez80"]
 i8080 = ["iz80"]
 mips = ["trapezoid-core"]
@@ -22,7 +21,6 @@ sm83 = ["mizu-core"]
 armv4t_emu = { version = "0.1.0", optional = true }
 rand = "0.10.0"
 unarm = { version = "2.1", optional = true }
-emu6809 = { version = "0.1.2", optional = true }
 iz80 = { version = "0.5.0", optional = true }
 mos6502 = {version = "0.9.0", optional = true }
 dez80 = { version = "4.0.1", optional = true }

--- a/README.md
+++ b/README.md
@@ -28,7 +28,6 @@ Strop currently has the following back-ends:
  * **m6502**, targets various models of the MOS 6502
     * Supports the NMOS and CMOS variants and others, thanks to the
       [mos6502](https://github.com/mre/mos6502) dependency.
- * **m6809**, which targets the Motorola 6809
  * **z80**, which targets the Zilog Z80
  * **sm83**, which targets the SM83, also known as the Gameboy CPU
  * **i8080**, which targets the Intel 8080.


### PR DESCRIPTION
the dependency has been yanked, so I'm removing it from here.

It wasn't doing anything anyway.

(There's [another emulator we could use](https://crates.io/crates/mc6809-core) instead which looks promising)